### PR TITLE
fixed broken links ATH-345

### DIFF
--- a/pages/logging/anthropic.mdx
+++ b/pages/logging/anthropic.mdx
@@ -2,7 +2,7 @@ import { Callout } from "nextra/components";
 
 <Callout emoji="!!">
   Make sure you have already completed the [Installation &
-  Setup](../../installation) steps before logging your data.
+  Setup](../../quickstart) steps before logging your data.
 </Callout>
 
 # Anthropic

--- a/pages/logging/langchain.mdx
+++ b/pages/logging/langchain.mdx
@@ -2,7 +2,7 @@ import { Callout } from "nextra/components";
 
 <Callout emoji="!!">
   Make sure you have already completed the [Installation &
-  Setup](../../installation) steps before logging your data.
+  Setup](../../quickstart) steps before logging your data.
 </Callout>
 
 # Langchain

--- a/pages/logging/meta_llama.mdx
+++ b/pages/logging/meta_llama.mdx
@@ -2,7 +2,7 @@ import { Callout } from "nextra/components";
 
 <Callout emoji="!!">
   Make sure you have already completed the [Installation &
-  Setup](../../installation) steps before logging your data.
+  Setup](../../quickstart) steps before logging your data.
 </Callout>
 
 # Meta Llama

--- a/pages/logging/misc.mdx
+++ b/pages/logging/misc.mdx
@@ -2,7 +2,7 @@ import { Callout } from "nextra/components";
 
 <Callout emoji="!!">
   Make sure you have already completed the [Installation &
-  Setup](../../installation) steps before logging your data.
+  Setup](../../quickstart) steps before logging your data.
 </Callout>
 
 # Other Language models

--- a/pages/logging/openai_completion.mdx
+++ b/pages/logging/openai_completion.mdx
@@ -2,7 +2,7 @@ import { Callout } from "nextra/components";
 
 <Callout emoji="!!">
   Make sure you have already completed the [Installation &
-  Setup](../../installation) steps before logging your data.
+  Setup](../../quickstart) steps before logging your data.
 </Callout>
 
 # OpenAI Completions

--- a/pages/logging/user_feedback.mdx
+++ b/pages/logging/user_feedback.mdx
@@ -2,7 +2,7 @@ import { Callout } from "nextra/components";
 
 <Callout emoji="!!">
   Make sure you have already completed the [Installation &
-  Setup](../../installation) steps before logging your data.
+  Setup](../../quickstart) steps before logging your data.
 </Callout>
 
 ### Log via Python SDK

--- a/pages/platform/overview.mdx
+++ b/pages/platform/overview.mdx
@@ -14,4 +14,4 @@ Athina's Monitoring Platform is designed for LLM developers and PMs.
 
 - [Detect Bad Outputs](./detect_bad_outputs): Detect and handle failures in real-time to ensure smooth and reliable model performance.
 
-- [5 Minute Integration](../logging/log_inference_call/openai_chat): Start logging your data in 5 mins, and we take care of the rest.
+- [5 Minute Integration](../logging/openai_chat): Start logging your data in 5 mins, and we take care of the rest.

--- a/pages/quickstart.mdx
+++ b/pages/quickstart.mdx
@@ -16,4 +16,4 @@ _Note: This will not work if you are using OpenAI streaming_
 
 ### Using a different setup?
 
-Next, start [logging your data](logging/log_inference_call/openai_chat).
+Next, start [logging your data](logging/openai_chat).


### PR DESCRIPTION
Linear ticket: https://linear.app/athina/issue/ATH-345/fix-broken-links-in-documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated hyperlinks across various documentation pages to redirect users from "Installation & Setup" to the "Quickstart" page for a more streamlined onboarding experience.
	- Modified the link for the "5 Minute Integration" feature to ensure users are directed to the correct logging instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->